### PR TITLE
DIR-6123: Return 403 for unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,6 +35,11 @@ http {
         add_header X-XSS-Protection "1; mode=block";
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self'; frame-ancestors https://detox.net/ https://*.detox.net/;";
 
+        # slow attacks by quickly returning unserved file types
+        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+             return 403;
+        }
+
         # proxy detox.net/wp-content/uploads/ -> s3 bucket
         location ^~ /wp-content/uploads/ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";


### PR DESCRIPTION
## [DIR-6123](https://recoverybrands.atlassian.net/browse/DIR-6123)

#### Brief Description

#### Example Link

#### Screenshot

#### Steps Needed to Reproduce Locally


[DIR-6123]: https://recoverybrands.atlassian.net/browse/DIR-6123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ