### PR TITLE
DIR-7041 update unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -36,8 +36,13 @@ http {
         add_header Content-Security-Policy "default-src *; font-src 'self' data: fonts.gstatic.com; style-src * 'unsafe-inline'; script-src * 'unsafe-inline' 'unsafe-eval'; img-src * data: 'unsafe-inline'; connect-src * 'unsafe-inline'; frame-src *; object-src 'none'; base-uri 'self'; frame-ancestors https://detox.net/ https://*.detox.net/;";
 
         # slow attacks by quickly returning unserved file types
-        location ~* \.(bak|zip|tar|gz|sql|php)$|/\. {
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
              return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # proxy detox.net/wp-content/uploads/ -> s3 bucket


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/DIR-7041

Brief Description:
DIR-7041 updated unserved file types

Example Links
https://staging.detox.net/test.env
https://staging.detox.net/test.aspx
https://staging.detox.net/test.env.aspx
https://staging.detox.net/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.detox.net/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/detox-net-nginx/assets/86256771/e5d18b0f-1c63-4112-a500-2a6e37157a0c)
